### PR TITLE
Update token

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Push Latest Tag
         uses: anothrNick/github-tag-action@1.71.0
         env:
-          GITHUB_TOKEN: ${{ secrets.STAKATER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: 'main'


### PR DESCRIPTION
Currently failing on push to main with:

```txt
2024-11-28T10:32:02Z: **pushing tag v0.0.6 to repo stakater/vale-package-se
  "message": "Bad credentials",
  "documentation_url": "https://docs.github.com/rest",
  "status": "401"
}
```